### PR TITLE
Remove canvas optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
   "homepage": "http://mozilla.github.io/pdf.js/",
   "bugs": "https://github.com/mozilla/pdf.js/issues",
   "license": "Apache-2.0",
-  "optionalDependencies": {
-    "canvas": "^2.11.0"
-  },
   "dependencies": {
     "web-streams-polyfill": "^3.2.1"
   },


### PR DESCRIPTION
Remove `canvas` optional dependency since it it automatically detected and used by jsdom if present, which is causing issues.